### PR TITLE
TACOSTART-1518 Display Bulk Status Response Info and File Download Buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@tabler/icons-react": "^3.6.0",
         "dotenv": "^16.4.5",
         "eslint-config-prettier": "^9.1.0",
+        "filesize": "^10.1.2",
         "next": "14.2.3",
         "react": "^18",
         "react-dom": "^18",
@@ -2344,6 +2345,14 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/filesize": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.2.tgz",
+      "integrity": "sha512-Dx770ai81ohflojxhU+oG+Z2QGvKdYxgEr9OSA8UVrqhwNHjfH9A8f5NKfg83fEH8ZFA5N5llJo5T3PIoZ4CRA==",
+      "engines": {
+        "node": ">= 10.4.0"
       }
     },
     "node_modules/fill-range": {
@@ -6916,6 +6925,11 @@
       "requires": {
         "flat-cache": "^3.0.4"
       }
+    },
+    "filesize": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.2.tgz",
+      "integrity": "sha512-Dx770ai81ohflojxhU+oG+Z2QGvKdYxgEr9OSA8UVrqhwNHjfH9A8f5NKfg83fEH8ZFA5N5llJo5T3PIoZ4CRA=="
     },
     "fill-range": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@tabler/icons-react": "^3.6.0",
     "dotenv": "^16.4.5",
     "eslint-config-prettier": "^9.1.0",
+    "filesize": "^10.1.2",
     "next": "14.2.3",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/export-execution/page.tsx
+++ b/src/app/export-execution/page.tsx
@@ -1,23 +1,78 @@
 'use client';
 
-import { Anchor, Flex, Stack, Title } from '@mantine/core';
+import { Anchor, Flex, Text, Stack, Title } from '@mantine/core';
 import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import FileDownloadCollapse from '@/components/export-execution/file-downloads';
+import { IconChevronUp, IconChevronDown } from '@tabler/icons-react';
+import { useDisclosure } from '@mantine/hooks';
+import PollingLogsList from '@/components/export-execution/polling-logs';
+
+export interface BulkExportResponse {
+  type: string;
+  url: string;
+}
+export interface PollingLog {
+  retryAfter: string;
+  xProgress: string;
+}
 
 export default function ExecutionPage() {
-  const searchParams = useSearchParams();
+  const [bulkExportData, setBulkExportData] = useState<BulkExportResponse[]>([]);
+  const [pollingLogs, setPollingLogs] = useState<PollingLog[]>([]);
+  const [bulkDataLoading, setBulkDataLoading] = useState(true);
+  const [filesOpened, { toggle }] = useDisclosure(true);
 
+  const searchParams = useSearchParams();
   const encodedContentLocation = searchParams.get('contentLocation');
-  if (!encodedContentLocation) return <Title>Error: Bad content-location</Title>;
+  if (!encodedContentLocation) return <Title>Error: Bad contentLocation</Title>;
   const contentLocation = decodeURIComponent(encodedContentLocation);
+
+  useEffect(() => {
+    const getBulkStatus = async () => {
+      const response = await fetch(contentLocation);
+      const xProgress = response.headers.get('x-progress');
+      const retryAfterString = response.headers.get('retry-after');
+
+      if (xProgress && retryAfterString) {
+        const newLog: PollingLog = {
+          retryAfter: retryAfterString,
+          xProgress: xProgress
+        };
+        setPollingLogs(prevLogs => [...prevLogs, newLog]);
+
+        const retryDelayMS = parseInt(retryAfterString, 10) * 1000;
+        await new Promise(resolve => setTimeout(resolve, retryDelayMS));
+
+        getBulkStatus();
+      } else {
+        const data = await response.json();
+        setBulkExportData(data.output);
+        setBulkDataLoading(false);
+      }
+    };
+    getBulkStatus();
+  }, []);
 
   return (
     <Stack>
+      <Title>Bulk Export Request Accepted</Title>
       <Flex>
         <Title mr="lg" order={3}>
           Content Location:
         </Title>
-        {contentLocation && <Anchor href={contentLocation}>{contentLocation}</Anchor>}
+        <Anchor href={contentLocation}>{contentLocation}</Anchor>
       </Flex>
+      <Flex onClick={toggle}>
+        <Title>Requested Files</Title>
+        {filesOpened ? <IconChevronUp size={50}></IconChevronUp> : <IconChevronDown size={50}></IconChevronDown>}
+      </Flex>
+      {bulkDataLoading ? (
+        <Text>No data yet...</Text>
+      ) : (
+        <FileDownloadCollapse files={bulkExportData} opened={filesOpened} />
+      )}
+      <PollingLogsList logs={pollingLogs} bulkDataCompleted={!bulkDataLoading}></PollingLogsList>
     </Stack>
   );
 }

--- a/src/app/export-execution/page.tsx
+++ b/src/app/export-execution/page.tsx
@@ -29,7 +29,11 @@ export default function ExecutionPage() {
   const contentLocation = decodeURIComponent(encodedContentLocation);
 
   useEffect(() => {
-    const getBulkStatus = async () => {
+    const getBulkStatus = async (retryLimit: number) => {
+      if (retryLimit <= 0) {
+        console.log('Retry limit of 10 hit. Stopping export...');
+        return;
+      }
       const response = await fetch(contentLocation);
       const xProgress = response.headers.get('x-progress');
       const retryAfterString = response.headers.get('retry-after');
@@ -44,14 +48,14 @@ export default function ExecutionPage() {
         const retryDelayMS = parseInt(retryAfterString, 10) * 1000;
         await new Promise(resolve => setTimeout(resolve, retryDelayMS));
 
-        getBulkStatus();
+        getBulkStatus(retryLimit - 1);
       } else {
         const data = await response.json();
         setBulkExportData(data.output);
         setBulkDataLoading(false);
       }
     };
-    getBulkStatus();
+    getBulkStatus(10);
   }, []);
 
   return (

--- a/src/app/export-execution/page.tsx
+++ b/src/app/export-execution/page.tsx
@@ -8,6 +8,11 @@ import { IconChevronUp, IconChevronDown } from '@tabler/icons-react';
 import { useDisclosure } from '@mantine/hooks';
 import PollingLogsList from '@/components/export-execution/polling-logs';
 
+/*
+ * Limit for the number of times the app can send a request to the bulk-export-server to try to get data at a content location.
+ */
+const FETCH_RETRY_LIMIT = 10;
+
 export interface BulkExportResponse {
   type: string;
   url: string;
@@ -55,7 +60,7 @@ export default function ExecutionPage() {
         setBulkDataLoading(false);
       }
     };
-    getBulkStatus(10);
+    getBulkStatus(FETCH_RETRY_LIMIT);
   }, []);
 
   return (

--- a/src/app/export-execution/page.tsx
+++ b/src/app/export-execution/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Anchor, Flex, Text, Stack, Title } from '@mantine/core';
+import { Anchor, Group, Stack, Title, Center, Loader } from '@mantine/core';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import FileDownloadCollapse from '@/components/export-execution/file-downloads';
@@ -21,7 +21,7 @@ export default function ExecutionPage() {
   const [bulkExportData, setBulkExportData] = useState<BulkExportResponse[]>([]);
   const [pollingLogs, setPollingLogs] = useState<PollingLog[]>([]);
   const [bulkDataLoading, setBulkDataLoading] = useState(true);
-  const [filesOpened, { toggle }] = useDisclosure(true);
+  const [requestedFilesOpened, { toggle }] = useDisclosure(true);
 
   const searchParams = useSearchParams();
   const encodedContentLocation = searchParams.get('contentLocation');
@@ -57,20 +57,26 @@ export default function ExecutionPage() {
   return (
     <Stack>
       <Title>Bulk Export Request Accepted</Title>
-      <Flex>
+      <Group>
         <Title mr="lg" order={3}>
           Content Location:
         </Title>
         <Anchor href={contentLocation}>{contentLocation}</Anchor>
-      </Flex>
-      <Flex onClick={toggle}>
+      </Group>
+      <Group gap="xs" onClick={toggle}>
         <Title>Requested Files</Title>
-        {filesOpened ? <IconChevronUp size={50}></IconChevronUp> : <IconChevronDown size={50}></IconChevronDown>}
-      </Flex>
+        {requestedFilesOpened ? (
+          <IconChevronUp size={50}></IconChevronUp>
+        ) : (
+          <IconChevronDown size={50}></IconChevronDown>
+        )}
+      </Group>
       {bulkDataLoading ? (
-        <Text>No data yet...</Text>
+        <Center>
+          <Loader />
+        </Center>
       ) : (
-        <FileDownloadCollapse files={bulkExportData} opened={filesOpened} />
+        <FileDownloadCollapse files={bulkExportData} opened={requestedFilesOpened} />
       )}
       <PollingLogsList logs={pollingLogs} bulkDataCompleted={!bulkDataLoading}></PollingLogsList>
     </Stack>

--- a/src/app/export-execution/page.tsx
+++ b/src/app/export-execution/page.tsx
@@ -87,7 +87,7 @@ export default function ExecutionPage() {
       ) : (
         <FileDownloadCollapse files={bulkExportData} opened={requestedFilesOpened} />
       )}
-      <PollingLogsList logs={pollingLogs} bulkDataCompleted={!bulkDataLoading}></PollingLogsList>
+      <PollingLogsList logs={pollingLogs} bulkDataCompleted={!bulkDataLoading} />
     </Stack>
   );
 }

--- a/src/components/export-execution/file-downloads.tsx
+++ b/src/components/export-execution/file-downloads.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react';
 import { filesize } from 'filesize';
 import { IconDownload } from '@tabler/icons-react';
 
-export interface FileSizeNameUrl {
+export interface FileInfo {
   name: string;
   url: string;
   size: number;
@@ -19,8 +19,8 @@ export interface FileDownloadCollapseProps {
 
 // Component for the collapsible section with the filenames and buttons to download them.
 export default function FileDownloadCollapse({ files, opened }: FileDownloadCollapseProps) {
-  const [fileSizeData, setFileSizeData] = useState<FileSizeNameUrl[]>([]);
-  const [totalFileSize, setTotalFileSize] = useState<number>(0);
+  const [fileSizeData, setFileSizeData] = useState<FileInfo[]>([]);
+  const [totalFileSize, setTotalFileSize] = useState(0);
 
   const noFilesFound = files.length === 0;
 
@@ -31,7 +31,7 @@ export default function FileDownloadCollapse({ files, opened }: FileDownloadColl
         fetch(file.url)
           .then(response => response.blob())
           .then(data => {
-            const fileSizeData: FileSizeNameUrl = { name: file.type, size: data.size, url: file.url };
+            const fileSizeData: FileInfo = { name: file.type, size: data.size, url: file.url };
 
             totalFileBytes += data.size;
 
@@ -43,7 +43,7 @@ export default function FileDownloadCollapse({ files, opened }: FileDownloadColl
         setFileSizeData(fileSizes);
         setTotalFileSize(totalFileBytes);
       })
-      .catch(error => console.error('Error:', error));
+      .catch(error => console.error('Error: ', error));
   }, []);
 
   return (

--- a/src/components/export-execution/file-downloads.tsx
+++ b/src/components/export-execution/file-downloads.tsx
@@ -16,6 +16,7 @@ export interface FileDownloadCollapseProps {
   opened: boolean;
 }
 
+// Component for the collapsible section with the filenames and buttons to download them.
 export default function FileDownloadCollapse({ files, opened }: FileDownloadCollapseProps) {
   const [fileSizeData, setFileSizeData] = useState<FileSizeNameUrl[]>([]);
   const [totalFileSize, setTotalFileSize] = useState<number>(0);
@@ -45,40 +46,30 @@ export default function FileDownloadCollapse({ files, opened }: FileDownloadColl
   }, []);
 
   return (
-    <>
-      <Collapse in={opened}>
-        <Stack>
-          {fileSizeData.map((file, index) => {
-            return (
-              <>
-                <Group justify="space-between" key={`group ${index}`}>
-                  <Title order={4} key={`title ${index}`}>
-                    {file.name}
-                  </Title>
-                  <Button
-                    component="a"
-                    href={file.url}
-                    key={`button ${index}`}
-                    rightSection={<IconDownload size={14} />}
-                    w={225}
-                  >
-                    Download ({filesize(file.size)})
-                  </Button>
-                </Group>
-                <Divider key={`divider ${index}`}></Divider>
-              </>
-            );
-          })}
-          {noFilesFound ? <Center>No Files Found...</Center> : <></>}
-          <Center mt="lg">
-            <Tooltip label="Not yet implemented...">
-              <Button size="lg" rightSection={<IconDownload size={24} />} disabled={true}>
-                Download All Files ({filesize(totalFileSize)})
-              </Button>
-            </Tooltip>
-          </Center>
-        </Stack>
-      </Collapse>
-    </>
+    <Collapse in={opened}>
+      <Stack>
+        {fileSizeData.map(file => {
+          return (
+            <Stack key={file.name}>
+              <Group justify="space-between">
+                <Title order={4}>{file.name}</Title>
+                <Button component="a" href={file.url} rightSection={<IconDownload size={14} />} w={225}>
+                  Download ({filesize(file.size)})
+                </Button>
+              </Group>
+              <Divider />
+            </Stack>
+          );
+        })}
+        {noFilesFound ? <Center>No Files Found...</Center> : <></>}
+        <Center mt="lg">
+          <Tooltip label="Not yet implemented...">
+            <Button size="lg" rightSection={<IconDownload size={24} />} disabled={true}>
+              Download All Files ({filesize(totalFileSize)})
+            </Button>
+          </Tooltip>
+        </Center>
+      </Stack>
+    </Collapse>
   );
 }

--- a/src/components/export-execution/file-downloads.tsx
+++ b/src/components/export-execution/file-downloads.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import { BulkExportResponse } from '@/app/export-execution/page';
 import { Button, Center, Group, Title, Collapse, Tooltip, Stack, Divider } from '@mantine/core';
 import { useEffect, useState } from 'react';
@@ -61,7 +62,7 @@ export default function FileDownloadCollapse({ files, opened }: FileDownloadColl
             </Stack>
           );
         })}
-        {noFilesFound ? <Center>No Files Found...</Center> : <></>}
+        {noFilesFound && <Center>No Files Found...</Center>}
         <Center mt="lg">
           <Tooltip label="Not yet implemented...">
             <Button size="lg" rightSection={<IconDownload size={24} />} disabled={true}>

--- a/src/components/export-execution/file-downloads.tsx
+++ b/src/components/export-execution/file-downloads.tsx
@@ -1,0 +1,84 @@
+'use client';
+import { BulkExportResponse } from '@/app/export-execution/page';
+import { Button, Center, Group, Title, Collapse, Tooltip, Stack, Divider } from '@mantine/core';
+import { useEffect, useState } from 'react';
+import { filesize } from 'filesize';
+import { IconDownload } from '@tabler/icons-react';
+
+export interface FileSizeNameUrl {
+  name: string;
+  url: string;
+  size: number;
+}
+
+export interface FileDownloadCollapseProps {
+  files: BulkExportResponse[];
+  opened: boolean;
+}
+
+export default function FileDownloadCollapse({ files, opened }: FileDownloadCollapseProps) {
+  const [fileSizeData, setFileSizeData] = useState<FileSizeNameUrl[]>([]);
+  const [totalFileSize, setTotalFileSize] = useState<number>(0);
+
+  const noFilesFound = files.length === 0;
+
+  useEffect(() => {
+    let totalFileBytes = 0;
+    Promise.all(
+      files.map(file =>
+        fetch(file.url)
+          .then(response => response.blob())
+          .then(data => {
+            const fileSizeData: FileSizeNameUrl = { name: file.type, size: data.size, url: file.url };
+
+            totalFileBytes += data.size;
+
+            return fileSizeData;
+          })
+      )
+    )
+      .then(fileSizes => {
+        setFileSizeData(fileSizes);
+        setTotalFileSize(totalFileBytes);
+      })
+      .catch(error => console.error('Error:', error));
+  }, []);
+
+  return (
+    <>
+      <Collapse in={opened}>
+        <Stack>
+          {fileSizeData.map((file, index) => {
+            return (
+              <>
+                <Group justify="space-between" key={`group ${index}`}>
+                  <Title order={4} key={`title ${index}`}>
+                    {file.name}
+                  </Title>
+                  <Button
+                    component="a"
+                    href={file.url}
+                    key={`button ${index}`}
+                    rightSection={<IconDownload size={14} />}
+                    w={225}
+                  >
+                    Download ({filesize(file.size)})
+                  </Button>
+                </Group>
+                <Divider key={`divider ${index}`}></Divider>
+              </>
+            );
+          })}
+          {noFilesFound ? <Center>No Files Found...</Center> : <></>}
+          <Center mt="lg">
+            <Tooltip label="Not yet implemented...">
+              <Button size="lg" rightSection={<IconDownload size={24} />} disabled={true}>
+                Download All Files ({filesize(totalFileSize)})
+              </Button>
+            </Tooltip>
+          </Center>
+        </Stack>
+      </Collapse>
+    </>
+  );
+}

--- a/src/components/export-execution/polling-logs.tsx
+++ b/src/components/export-execution/polling-logs.tsx
@@ -1,5 +1,5 @@
 import { PollingLog } from '@/app/export-execution/page';
-import { useMantineTheme, Flex, Title, Collapse, Stack, Group, Text } from '@mantine/core';
+import { useMantineTheme, Title, Collapse, Stack, Group, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { IconChevronUp, IconChevronDown } from '@tabler/icons-react';
 
@@ -8,21 +8,22 @@ export interface PollingLogsListProps {
   bulkDataCompleted: boolean;
 }
 
+// Component for the collapsible section with the polling logs
 export default function PollingLogsList({ logs, bulkDataCompleted }: PollingLogsListProps) {
   const theme = useMantineTheme();
   const [opened, { toggle }] = useDisclosure(true);
 
   return (
     <>
-      <Flex onClick={toggle}>
+      <Group gap="xs" onClick={toggle}>
         <Title>Polling Logs</Title>
         {opened ? <IconChevronUp size={50}></IconChevronUp> : <IconChevronDown size={50}></IconChevronDown>}
-      </Flex>
+      </Group>
       <Collapse in={opened}>
         <Stack bg={theme.colors.gray[5]} p="xl">
           {logs.map((log, index) => {
             return (
-              <Group key={index + 1} justify="center" grow bg="white" p="lg">
+              <Group key={index} justify="center" grow bg="white" p="lg">
                 <Text ta="left">Log {index + 1}</Text>
                 <Text fz="xl" ta="center">
                   {log.xProgress}

--- a/src/components/export-execution/polling-logs.tsx
+++ b/src/components/export-execution/polling-logs.tsx
@@ -1,0 +1,43 @@
+import { PollingLog } from '@/app/export-execution/page';
+import { useMantineTheme, Flex, Title, Collapse, Stack, Group, Text } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { IconChevronUp, IconChevronDown } from '@tabler/icons-react';
+
+export interface PollingLogsListProps {
+  logs: PollingLog[];
+  bulkDataCompleted: boolean;
+}
+
+export default function PollingLogsList({ logs, bulkDataCompleted }: PollingLogsListProps) {
+  const theme = useMantineTheme();
+  const [opened, { toggle }] = useDisclosure(true);
+
+  return (
+    <>
+      <Flex onClick={toggle}>
+        <Title>Polling Logs</Title>
+        {opened ? <IconChevronUp size={50}></IconChevronUp> : <IconChevronDown size={50}></IconChevronDown>}
+      </Flex>
+      <Collapse in={opened}>
+        <Stack bg={theme.colors.gray[5]} p="xl">
+          {logs.map((log, index) => {
+            return (
+              <Group key={index + 1} justify="center" grow bg="white" p="lg">
+                <Text ta="left">Log {index + 1}</Text>
+                <Text fz="xl" ta="center">
+                  {log.xProgress}
+                </Text>
+                <Text ta="right">Retry after {log.retryAfter}s</Text>
+              </Group>
+            );
+          })}
+          {bulkDataCompleted && (
+            <Text fz="xl" fw={700} ta="center" bg="white" p="lg">
+              Bulk export ready
+            </Text>
+          )}
+        </Stack>
+      </Collapse>
+    </>
+  );
+}


### PR DESCRIPTION
# Summary

This PR adds bulk status response information to the export execution page. When the request is complete, you can now see the files that were returned and can download them. While the request is being completed, you should see request polling information, with the poll number, progress and how many seconds until the next poll will be executed.

[JIRA Issue](https://jira.mitre.org/browse/TACOSTRAT-1518)


### Important: 
If you want to simulate the request process with the server taking longer to generate a response, go to line 17 of `exportWorker.js` in the bulk export server and add this line:

`await new Promise(resolve => setTimeout(resolve, 5000));` 

This adds a five second delay to the export worker. Save this and stop and rerun the server.


## New behavior

When you click the blue button to the right of the export request string on the query-builder page, you will now be navigated to the export-execution page, where you will see 3 sections. The first is unchanged; it shows the content location. The second section is the requested files section, which initially will have a loader while the files are being fetched. The third section is the polling logs that will display information about the request as it comes from the server. When the request is complete, the requested files section will be populated with the file paths from the server.


## Code changes

- `package.json` - added filesize package to display filesize in a more human readable way much.
- `src/app/export-execution/page.tsx` - added the above functionality. Uses a use effect that fetches from the content location until the response does not have the xProgress and retryAfter headers.
- `src/components/export-execution/file-downloads.tsx` - displays the files that come from the content location along with their filesizes in a stack with buttons to download them.
- `src/components/export-execution/polling-logs.tsx` - displays information returned from requesting the content-location before it is ready.

# Testing guidance
- Make sure that the changes to the bulk-export-server are made described in the summary section
- run the bulk export server
- `npm run check`
- `npm run build`
- `npm run start`
- Navigate to localhost:3001 and navigate through the page as usual, selecting an export level, some parameters and then run the query.
- Click the green magnifiying glass.
- Look for the polling logs to come up.
- Verify that the export completes.
- Check that files appear and download buttons work
- Verify there are no errors in the console.
