### PR TITLE
Remove all button is disabled when there are no created type filters

### DIFF
--- a/src/components/parameter-pages/type-filter-table.tsx
+++ b/src/components/parameter-pages/type-filter-table.tsx
@@ -128,7 +128,7 @@ export default function TypeFilterTable({ setFilterInput }: { setFilterInput: Di
           </Text>
         )}
         <Flex justify="right">
-          <Button color="red" onClick={() => setTypeFilters([])} disabled={activeTypeFilters.length === 0}>
+          <Button color="red" onClick={() => setTypeFilters([])} disabled={typeFilters.length === 0}>
             Remove All
           </Button>
         </Flex>


### PR DESCRIPTION
I changed over to active type filters and forgot that this logic should not use the active type filters.