### PR TITLE
Added switch to organizeOutputByPatient

### DIFF
--- a/src/app/query-builder/page.tsx
+++ b/src/app/query-builder/page.tsx
@@ -6,6 +6,7 @@ import { SupportedExportTypes } from '@/components/query-selector/export-type';
 import { Suspense } from 'react';
 import ElementParamsPage from '@/components/parameter-pages/elements-params-page';
 import TypeFilterParamsPage from '@/components/parameter-pages/type-filter-params-page';
+import OrganizeOutputByPatientSwitch from '@/components/parameter-pages/organize-output-by-swtich';
 
 /*
  * Properties of the query string that can be passed to this page
@@ -58,6 +59,22 @@ export default function QueryBuilder() {
               <TypeFilterParamsPage />
             </TabsPanel>
           </Tabs>
+        </Container>
+      </Card>
+      <Card>
+        <Container fluid m="xl">
+          <Flex align="center" mb="lg">
+            <Title mr="sm">Organize Output By Patient</Title>
+            <Tooltip
+              position="right"
+              withArrow
+              transitionProps={{ duration: 200 }}
+              label="Set organizeOutputBy to Patient"
+            >
+              <IconInfoCircle color="gray" />
+            </Tooltip>
+          </Flex>
+          <OrganizeOutputByPatientSwitch />
         </Container>
       </Card>
     </>

--- a/src/components/parameter-pages/organize-output-by-swtich.tsx
+++ b/src/components/parameter-pages/organize-output-by-swtich.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { organizeOutputByPatientState } from '@/state/organize-output-by-patient-state';
+import { Switch } from '@mantine/core';
+import { useRecoilState } from 'recoil';
+
+export default function OrganizeOutputByPatientSwitch() {
+  const [organizeOutputByPatient, setOrganizeOutputByPatient] = useRecoilState(organizeOutputByPatientState);
+
+  return (
+    <Switch
+      label="Add organizeOutputBy=Patient to the query string"
+      onLabel="YES"
+      offLabel="NO"
+      size="lg"
+      checked={organizeOutputByPatient}
+      onChange={event => setOrganizeOutputByPatient(event.currentTarget.checked)}
+    />
+  );
+}

--- a/src/components/parameter-pages/organize-output-by-swtich.tsx
+++ b/src/components/parameter-pages/organize-output-by-swtich.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { organizeOutputByPatientState } from '@/state/organize-output-by-patient-state';
-import { Switch } from '@mantine/core';
+import { Code, Switch, Text } from '@mantine/core';
 import { useRecoilState } from 'recoil';
 
 export default function OrganizeOutputByPatientSwitch() {
@@ -9,7 +9,11 @@ export default function OrganizeOutputByPatientSwitch() {
 
   return (
     <Switch
-      label="Add organizeOutputBy=Patient to the query string"
+      label={
+        <Text>
+          Add <Code>organizeOutputBy=Patient</Code>to the query string?
+        </Text>
+      }
       onLabel="YES"
       offLabel="NO"
       size="lg"

--- a/src/components/query-string.tsx
+++ b/src/components/query-string.tsx
@@ -28,6 +28,7 @@ import { activeElementParamsState } from '@/state/element-params-state';
 import { activeTypeElementParamsState } from '@/state/type-element-params-state';
 import { bulkServerURLState } from '@/state/bulk-server-url-state';
 import { activeTypeFiltersState } from '@/state/selectors/type-filter-selectors';
+import { organizeOutputByPatientState } from '@/state/organize-output-by-patient-state';
 
 /*
  * Component to visualize the Bulk-export request string.
@@ -40,6 +41,7 @@ export default function QueryString() {
   const typeElementParams = useRecoilValue(activeTypeElementParamsState);
   const elementParams = useRecoilValue(activeElementParamsState);
   const activeTypeFilters = useRecoilValue(activeTypeFiltersState);
+  const organizeOutputByPatient = useRecoilValue(organizeOutputByPatientState);
 
   const searchParams = useSearchParams();
   const exportType = searchParams.get('exportType') as SupportedExportTypes;
@@ -49,7 +51,8 @@ export default function QueryString() {
     type: typeParams,
     element: elementParams,
     typeElement: typeElementParams,
-    typeFilter: activeTypeFilters
+    typeFilter: activeTypeFilters,
+    organizeOutputByPatient: organizeOutputByPatient
   };
   const exportRequestString = buildExportRequestString({
     baseUrl: bulkExportBaseURL,

--- a/src/state/organize-output-by-patient-state.ts
+++ b/src/state/organize-output-by-patient-state.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+/**
+ * Recoil state to set the value of organizeInputByPatient atom to true or false
+ */
+export const organizeOutputByPatientState = atom<boolean>({ key: 'organizeOutputByPatientState', default: false });

--- a/src/util/exportRequestBuilder.ts
+++ b/src/util/exportRequestBuilder.ts
@@ -20,6 +20,7 @@ export interface BuilderRequestQueryParams {
   element: string[];
   typeElement: TypeElement[];
   typeFilter: TypeFilter[];
+  organizeOutputByPatient: boolean;
 }
 
 /*
@@ -62,6 +63,10 @@ function buildQueryString(queryParams: BuilderRequestQueryParams) {
     paramsArray.push(
       `_typeFilter=${queryParams.typeFilter.map(typeFilter => encodeURIComponent(typeFilter.filter)).toString()}`
     );
+  }
+
+  if (queryParams.organizeOutputByPatient === true) {
+    paramsArray.push(`organizeOutputBy=Patient`);
   }
 
   if (paramsArray.length === 0) return;


### PR DESCRIPTION
# Summary
Adds a switch in the UI (for all export types, system, patient, and group) to add `organizeOutputBy=Patient` to the query string.

## New Behavior
- The user has the ability to add `organizeOutputBy=Patient` to the query string with a switch.

## Code Changes
- `query-builder/page.tsx` - add switch to the query builder page
- `organize-output-by-switch.tsx` - switch component 
- `query-string.tsx` - add input to queryParams
- `organize-output-by-patient-state.tsx` - atom for this new query parameter
- `exportRequestBuilder.tsx` - add to query string 

# Testing
- `npm run check` (no unit tests, just prettier and lint)
- `npm run dev`
- You can either point it to our hosted bulk-export-server (https://abacus-dev.mitre.org/bulk-export/) or run `npm run start` in your local bulk-export-server and use http://localhost:3000
- Make sure that the switch works as expected. Note that our server does not currently have functionality for the  `organizeOutputBy` query parameter, so the export will not work with that enabled