### PR TITLE
Only load NDJSON export files on request

### DIFF
--- a/src/components/export-execution/requested-files.tsx
+++ b/src/components/export-execution/requested-files.tsx
@@ -11,7 +11,8 @@ import {
   Card,
   Modal,
   Loader,
-  Text
+  Text,
+  Button
 } from '@mantine/core';
 import { IconFileDownload, IconFileSearch } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
@@ -30,6 +31,11 @@ export interface ResourceFileInfo {
   objectArray: Resource[];
 }
 
+export interface ResourceFileInfos {
+  name: string;
+  url: string;
+}
+
 export interface RequestedFilesProps {
   files: BulkExportResponse[];
   opened: boolean;
@@ -37,39 +43,53 @@ export interface RequestedFilesProps {
 
 // Component for the collapsible section with the filenames and buttons to download them.
 export default function RequestedFiles({ files, opened }: RequestedFilesProps) {
-  const [fileSizeData, setFileSizeData] = useState<ResourceFileInfo[]>([]);
+  const [fileSizeData, setFileSizeData] = useState<ResourceFileInfos[]>([]);
   const [totalFileSize, setTotalFileSize] = useState(0);
   const [previewedFile, setPreviewedFile] = useState<ResourceFileInfo>();
   const [jsonModalOpened, { open, close }] = useDisclosure(false);
-
+  const [fileDataLookup, setFileDataLookup] = useState<Record<string, ResourceFileInfo>>({});
+  const [resourceInfoLoading, setResourceInfoLoading] = useState<Record<string, boolean>>({});
   const [loading, setLoading] = useState(false);
 
   const noFilesFound = files.length === 0;
 
+  const retrieveInfo = (file: ResourceFileInfos) => {
+    setResourceInfoLoading(prevData => ({ ...prevData, [file.name]: true }));
+    let totalFileBytes = 0;
+    fetch(file.url)
+      .then(response => response.blob())
+      .then(data => data.text())
+      .then(ndjsonData => {
+        const fileData: ResourceFileInfo = {
+          name: file.name,
+          size: ndjsonData.length,
+          url: file.url,
+          numResources: ndjsonData.split('\n').length,
+          objectArray: parseNdjson(ndjsonData)
+        };
+        totalFileBytes += ndjsonData.length;
+        return fileData;
+      })
+      .then(fileData => {
+        setFileDataLookup(prevData => ({ ...prevData, [fileData.name]: fileData }));
+        setTotalFileSize(totalFileSize + totalFileBytes);
+        setResourceInfoLoading(prevData => ({ ...prevData, [file.name]: false }));
+      });
+  };
+
   useEffect(() => {
     setLoading(true);
-    let totalFileBytes = 0;
     Promise.all(
-      files.map(file =>
-        fetch(file.url)
-          .then(response => response.blob())
-          .then(data => data.text())
-          .then(ndjsonData => {
-            const fileSizeData: ResourceFileInfo = {
-              name: file.type,
-              size: ndjsonData.length,
-              url: file.url,
-              numResources: ndjsonData.split('\n').length,
-              objectArray: parseNdjson(ndjsonData)
-            };
-            totalFileBytes += ndjsonData.length;
-            return fileSizeData;
-          })
-      )
+      files.map(file => {
+        const fileData: ResourceFileInfos = {
+          name: file.type,
+          url: file.url
+        };
+        return fileData;
+      })
     )
-      .then(fileSizes => {
-        setFileSizeData(fileSizes);
-        setTotalFileSize(totalFileBytes);
+      .then(fileData => {
+        setFileSizeData(fileData);
         setLoading(false);
       })
       .catch(error => console.error('Error: ', error));
@@ -99,7 +119,7 @@ export default function RequestedFiles({ files, opened }: RequestedFilesProps) {
           <Center>
             <Card>
               <Title order={4}>
-                Total Size of Exported Files:{' '}
+                Total Size of Downloaded Export Files:{' '}
                 <Text span inherit c="blue.9" inline>
                   {filesize(totalFileSize)}
                 </Text>
@@ -115,34 +135,43 @@ export default function RequestedFiles({ files, opened }: RequestedFilesProps) {
                   {file.name}
                 </Title>
                 <Group>
-                  <Tooltip label={`Number of exported "${file.name}" resources`} openDelay={500} withArrow>
-                    <Badge fz={14} size="md" variant="outline" color="dark.4">
-                      {file.numResources} {file.numResources === 1 ? 'Resource' : 'Resources'}
-                    </Badge>
-                  </Tooltip>
-                  <Tooltip label="Size of exported .ndjson file" openDelay={500} withArrow>
-                    <Badge fz={15} variant="light" size="lg" color="dark.6">
-                      {filesize(file.size)}
-                    </Badge>
-                  </Tooltip>
-                  <Tooltip label={`Preview ${file.name}.ndjson`} openDelay={500} withArrow>
-                    <ActionIcon
-                      size="lg"
-                      radius="md"
-                      color="blue.4"
-                      onClick={() => {
-                        setPreviewedFile(file);
-                        open();
-                      }}
-                    >
-                      <IconFileSearch />
-                    </ActionIcon>
-                  </Tooltip>
-                  <Tooltip label={`Download ${file.name}.ndjson`} openDelay={500} withArrow>
-                    <ActionIcon component="a" href={file.url} size="lg" radius="md">
-                      <IconFileDownload />
-                    </ActionIcon>
-                  </Tooltip>
+                  {resourceInfoLoading[file.name] === true ? (
+                    <Loader />
+                  ) : fileDataLookup[file.name] ? (
+                    <Group>
+                      <Tooltip label={`Number of exported "${file.name}" resources`} openDelay={500} withArrow>
+                        <Badge fz={14} size="md" variant="outline" color="dark.4">
+                          {fileDataLookup[file.name].numResources}{' '}
+                          {fileDataLookup[file.name].numResources === 1 ? 'Resource' : 'Resources'}
+                        </Badge>
+                      </Tooltip>
+                      <Tooltip label="Size of exported .ndjson file" openDelay={500} withArrow>
+                        <Badge fz={15} variant="light" size="lg" color="dark.6">
+                          {filesize(fileDataLookup[file.name].size)}
+                        </Badge>
+                      </Tooltip>
+                      <Tooltip label={`Preview ${file.name}.ndjson`} openDelay={500} withArrow>
+                        <ActionIcon
+                          size="lg"
+                          radius="md"
+                          color="blue.4"
+                          onClick={() => {
+                            setPreviewedFile(fileDataLookup[file.name]);
+                            open();
+                          }}
+                        >
+                          <IconFileSearch />
+                        </ActionIcon>
+                      </Tooltip>
+                      <Tooltip label={`Download ${file.name}.ndjson`} openDelay={500} withArrow>
+                        <ActionIcon component="a" href={file.url} size="lg" radius="md">
+                          <IconFileDownload />
+                        </ActionIcon>
+                      </Tooltip>
+                    </Group>
+                  ) : (
+                    <Button onClick={() => retrieveInfo(file)}>Load NDJSON Information</Button>
+                  )}
                 </Group>
               </Group>
             </Card>


### PR DESCRIPTION
# Summary
This PR changes the bulk export app workflow to no longer automatically load the NDJSON content from the exported files, the user has to specifically request it in the UI.

## New Behavior
The exported NDJSON content is no longer automatically loaded, there is now a button in the UI for each exported resource NDJSON file to load the NDJSON content. 

## Code Changes
- `src/components/export-execution/requested-files.tsx` - New interface to only load the file name and url for each resource ndjson automatically. New button for the user to request the NDJSON content.

# Testing
- `npm run check` (no unit tests, just prettier and lint)
- `npm run dev`
- You can either point it to our hosted bulk-export-server (https://abacus-dev.mitre.org/bulk-export/) or run `npm run start` in your local bulk-export-server and use http://localhost:3000
- Make sure the buttons work as expected 