### PR TITLE
Group creation

### DIFF
--- a/src/app/query-builder/page.tsx
+++ b/src/app/query-builder/page.tsx
@@ -64,7 +64,7 @@ export default function QueryBuilder() {
         console.error(err);
         showNotification({
           icon: <IconAlertCircle />,
-          title: 'Group creation failed',
+          title: 'Group Creation Failed',
           message: `Group creation failed with error: ${err}`,
           color: 'red'
         });

--- a/src/app/query-builder/page.tsx
+++ b/src/app/query-builder/page.tsx
@@ -1,12 +1,34 @@
-import { Card, Center, Container, Flex, Tabs, TabsList, TabsPanel, TabsTab, Title, Tooltip } from '@mantine/core';
+'use client';
+
+import {
+  Button,
+  Card,
+  Center,
+  Container,
+  Flex,
+  ScrollArea,
+  Tabs,
+  TabsList,
+  TabsPanel,
+  TabsTab,
+  Title,
+  Tooltip
+} from '@mantine/core';
 import QueryString from '@/components/query-string';
 import TypeParamsPage from '@/components/parameter-pages/type-params-page';
-import { IconInfoCircle } from '@tabler/icons-react';
+import { IconAlertCircle, IconCircleCheck, IconInfoCircle } from '@tabler/icons-react';
 import { SupportedExportTypes } from '@/components/query-selector/export-type';
-import { Suspense } from 'react';
+import { Suspense, useState } from 'react';
 import ElementParamsPage from '@/components/parameter-pages/elements-params-page';
 import TypeFilterParamsPage from '@/components/parameter-pages/type-filter-params-page';
 import OrganizeOutputByPatientSwitch from '@/components/parameter-pages/organize-output-by-swtich';
+import { showNotification } from '@mantine/notifications';
+import { useRecoilValue } from 'recoil';
+import { measureBundleState } from '@/state/measure-bundle';
+import { useSearchParams } from 'next/navigation';
+import { CodeHighlight } from '@mantine/code-highlight';
+import { bulkServerURLState } from '@/state/bulk-server-url-state';
+import Link from 'next/link';
 
 /*
  * Properties of the query string that can be passed to this page
@@ -17,6 +39,38 @@ export interface SearchParamsProps {
 }
 
 export default function QueryBuilder() {
+  const searchParams = useSearchParams();
+  const measureBundle = useRecoilValue(measureBundleState);
+  const bulkExportBaseURL = useRecoilValue(bulkServerURLState);
+  const [groupId, setGroupId] = useState(null);
+
+  const createGroup = () => {
+    fetch(`${bulkExportBaseURL}/Group`, {
+      method: 'POST',
+      body: measureBundle.groupText,
+      headers: { 'Content-Type': 'application/json+fhir' }
+    })
+      .then(response => response.json())
+      .then(resObj => {
+        setGroupId(resObj.id);
+        showNotification({
+          icon: <IconCircleCheck />,
+          title: 'Group Creation Success',
+          message: `Successfully created group at id ${resObj.id}`,
+          color: 'green'
+        });
+      })
+      .catch(err => {
+        console.error(err);
+        showNotification({
+          icon: <IconAlertCircle />,
+          title: 'Group creation failed',
+          message: `Group creation failed with error: ${err}`,
+          color: 'red'
+        });
+      });
+  };
+
   return (
     <>
       <Center mt="xl">
@@ -24,43 +78,64 @@ export default function QueryBuilder() {
           <QueryString />
         </Suspense>
       </Center>
-      <Card>
-        <Container fluid m="xl">
-          <Flex align="center" mb="lg">
-            <Title mr="sm">Parameters</Title>
-            <Tooltip
-              position="right"
-              withArrow
-              transitionProps={{ duration: 200 }}
-              label="Add parameters to your bulk export query"
-            >
-              <IconInfoCircle color="gray" />
-            </Tooltip>
-          </Flex>
-          <Tabs defaultValue="type-tab" orientation="vertical" radius="md">
-            <TabsList fw={600}>
-              <TabsTab fz="h2" p="lg" value="type-tab">
-                Types
-              </TabsTab>
-              <TabsTab fz="h2" p="lg" value="element-tab">
-                Elements
-              </TabsTab>
-              <TabsTab fz="h2" p="lg" value="type-filters-tab">
-                Type Filters
-              </TabsTab>
-            </TabsList>
-            <TabsPanel ml="xl" value="type-tab">
-              <TypeParamsPage />
-            </TabsPanel>
-            <TabsPanel ml="xl" value="element-tab">
-              <ElementParamsPage />
-            </TabsPanel>
-            <TabsPanel ml="xl" value="type-filters-tab">
-              <TypeFilterParamsPage />
-            </TabsPanel>
-          </Tabs>
-        </Container>
-      </Card>
+      {searchParams.get('exportType') === 'measure-bundle' ? (
+        <Card>
+          <ScrollArea.Autosize mah={600} mx="auto" scrollbars="y" bd="1px solid gray.2" mr="lg" ml="lg" mt="lg" mb="lg">
+            <CodeHighlight withCopyButton={true} code={measureBundle.groupText} language="json" />
+          </ScrollArea.Autosize>
+          {groupId ? (
+            <Center>
+              <Link href={`/query-builder?exportType=group&id=${groupId}`}>
+                <Button disabled={!groupId}>Group Export</Button>
+              </Link>
+            </Center>
+          ) : (
+            <Center>
+              <Button disabled={measureBundle.groupText === 'No group content'} onClick={createGroup}>
+                Create
+              </Button>
+            </Center>
+          )}
+        </Card>
+      ) : (
+        <Card>
+          <Container fluid m="xl">
+            <Flex align="center" mb="lg">
+              <Title mr="sm">Parameters</Title>
+              <Tooltip
+                position="right"
+                withArrow
+                transitionProps={{ duration: 200 }}
+                label="Add parameters to your bulk export query"
+              >
+                <IconInfoCircle color="gray" />
+              </Tooltip>
+            </Flex>
+            <Tabs defaultValue="type-tab" orientation="vertical" radius="md">
+              <TabsList fw={600}>
+                <TabsTab fz="h2" p="lg" value="type-tab">
+                  Types
+                </TabsTab>
+                <TabsTab fz="h2" p="lg" value="element-tab">
+                  Elements
+                </TabsTab>
+                <TabsTab fz="h2" p="lg" value="type-filters-tab">
+                  Type Filters
+                </TabsTab>
+              </TabsList>
+              <TabsPanel ml="xl" value="type-tab">
+                <TypeParamsPage />
+              </TabsPanel>
+              <TabsPanel ml="xl" value="element-tab">
+                <ElementParamsPage />
+              </TabsPanel>
+              <TabsPanel ml="xl" value="type-filters-tab">
+                <TypeFilterParamsPage />
+              </TabsPanel>
+            </Tabs>
+          </Container>
+        </Card>
+      )}
       <Card>
         <Container fluid m="xl">
           <Flex align="center" mb="lg">


### PR DESCRIPTION
Note: currently branched off PR: https://github.com/projecttacoma/bulk-export-app/pull/18

# Summary
Adds in the group management UI components for a custom group as generated from the measure bundle by the fqm-bulk-utils library.

## New Behavior
The measure-bundle export page now contains a copyable view of the custom group json object (instead of the query building tooling of the other pages). Also contains a Create button for posting the group to the server, which turns into a redirect to the group export page (with that group selected) once the group has been posted.

## Code Changes

- Update `query-builder/page.tsx` to show a CodeHighlight component with the custom group json when the export type is `measure-bundle`. Add buttons for creating the group and going to the group export page for that created group.

# Testing
- `npm run check`
- `npm run dev`
- You can either point it to our hosted bulk-export-server (https://abacus-dev.mitre.org/bulk-export/) or run `npm run start` in your local bulk-export-server and use http://localhost:3000
- Load a bundle in the `Measure-bundle-level Export` card and select `Build Query`, then view the group text (try the copy button!).
- Try the Create button beneath the group text and note the group id in the success notification. Then click on "Group Export" and make sure that you're redirected to a group export with the noted group id.